### PR TITLE
Add comprehensive SSH connection guide for GitHub

### DIFF
--- a/docs/ssh/README.md
+++ b/docs/ssh/README.md
@@ -1,0 +1,91 @@
+# Connecting to GitHub with SSH
+
+You can connect to GitHub using the Secure Shell Protocol (SSH), which provides a secure channel over an unsecured network.
+
+## Overview
+
+SSH is a secure protocol used as the primary means of connecting to Linux servers remotely. It provides a text-based interface by spawning a remote shell. After connecting, all commands you type in your local terminal are sent to the remote server and executed there.
+
+When you set up SSH with GitHub, you can push and pull to/from repositories without having to supply your username and personal access token at each visit.
+
+## Table of Contents
+
+1. [About SSH](./about-ssh.md) - Learn what SSH is and why you should use it
+2. [Checking for Existing SSH Keys](./checking-for-existing-ssh-keys.md) - Before you generate an SSH key, check for existing keys
+3. [Generating a New SSH Key](./generating-a-new-ssh-key.md) - Generate a new SSH key and add it to the ssh-agent
+4. [Adding a New SSH Key to Your GitHub Account](./adding-ssh-key-to-github.md) - Add your public SSH key to GitHub
+5. [Testing Your SSH Connection](./testing-ssh-connection.md) - Verify your SSH connection works
+6. [Working with SSH Key Passphrases](./ssh-key-passphrases.md) - Manage and secure your SSH key passphrases
+7. [Using SSH Agent Forwarding](./ssh-agent-forwarding.md) - Securely use your local SSH keys on remote servers
+8. [Managing Deploy Keys](./managing-deploy-keys.md) - Set up SSH keys for repository-specific access
+
+## Quick Start
+
+If you're new to SSH and want to get started quickly:
+
+1. **Check for existing SSH keys** - You may already have SSH keys on your computer
+   ```bash
+   ls -al ~/.ssh
+   ```
+
+2. **Generate a new SSH key** - If you don't have one, create a new SSH key pair
+   ```bash
+   ssh-keygen -t ed25519 -C "your_email@example.com"
+   ```
+
+3. **Add your SSH key to ssh-agent** - Start the ssh-agent and add your key
+   ```bash
+   eval "$(ssh-agent -s)"
+   ssh-add ~/.ssh/id_ed25519
+   ```
+
+4. **Add the SSH key to your GitHub account** - Copy your public key and add it to GitHub
+   ```bash
+   cat ~/.ssh/id_ed25519.pub
+   ```
+   Then go to GitHub Settings → SSH and GPG keys → New SSH key
+
+5. **Test your connection**
+   ```bash
+   ssh -T git@github.com
+   ```
+
+## Prerequisites
+
+- A GitHub account
+- Access to a terminal/command line
+- Basic familiarity with command line operations
+
+## Platform-Specific Guides
+
+The instructions in this guide work across multiple platforms:
+
+- **macOS**: Use the built-in Terminal application
+- **Linux**: Use your distribution's terminal
+- **Windows**: Use Git Bash, WSL, or PowerShell
+
+## Getting Help
+
+If you encounter issues:
+
+1. Check the [Testing Your SSH Connection](./testing-ssh-connection.md) guide for troubleshooting
+2. Review the [SSH Key Passphrases](./ssh-key-passphrases.md) guide if you're having passphrase issues
+3. Consult [GitHub's SSH documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
+
+## Security Best Practices
+
+- Always use a passphrase to protect your SSH keys
+- Use Ed25519 algorithm for new keys (more secure and performant than RSA)
+- Never share your private key (`id_ed25519` or `id_rsa`)
+- Only share your public key (`id_ed25519.pub` or `id_rsa.pub`)
+- Regularly audit and remove unused SSH keys from your GitHub account
+
+## Additional Resources
+
+- [GitHub Documentation](https://docs.github.com)
+- [OpenSSH Manual](https://www.openssh.com/manual.html)
+- [SSH Protocol Specification](https://www.ssh.com/academy/ssh/protocol)
+
+---
+
+Ready to get started? Begin with [About SSH](./about-ssh.md) to learn more about the protocol, or jump straight to [Checking for Existing SSH Keys](./checking-for-existing-ssh-keys.md) to begin the setup process.

--- a/docs/ssh/about-ssh.md
+++ b/docs/ssh/about-ssh.md
@@ -1,0 +1,141 @@
+# About SSH
+
+SSH (Secure Shell) is a cryptographic network protocol that allows you to securely connect to remote computers and servers over an unsecured network.
+
+## What is SSH?
+
+SSH provides a secure channel over an unsecured network by using a client-server architecture. It was designed as a replacement for older, insecure protocols like Telnet and FTP that transmitted data, including passwords, in plain text.
+
+### Key Features
+
+- **Encryption**: All data transmitted between the client and server is encrypted
+- **Authentication**: Multiple methods to verify identity (passwords, public key, certificates)
+- **Integrity**: Ensures data hasn't been tampered with during transmission
+- **Port Forwarding**: Ability to tunnel other protocols through SSH
+
+## Why Use SSH with GitHub?
+
+When you use SSH with GitHub, you gain several benefits:
+
+1. **No Password Required**: Once set up, you don't need to enter your username and password for every Git operation
+2. **Enhanced Security**: More secure than HTTPS with password authentication
+3. **Automation**: Easier to automate Git operations in scripts and CI/CD pipelines
+4. **Multiple Key Support**: You can use different SSH keys for different accounts or organizations
+
+## How SSH Works
+
+SSH uses public-key cryptography to authenticate users:
+
+1. **Key Pair Generation**: You generate a pair of cryptographic keys
+   - **Private Key**: Kept secret on your computer (e.g., `~/.ssh/id_ed25519`)
+   - **Public Key**: Shared with services like GitHub (e.g., `~/.ssh/id_ed25519.pub`)
+
+2. **Authentication Process**:
+   - You attempt to connect to GitHub
+   - GitHub sends a challenge encrypted with your public key
+   - Your computer uses the private key to decrypt and respond
+   - If the response is correct, you're authenticated
+
+3. **Secure Communication**: Once authenticated, all data is encrypted using session keys
+
+## SSH vs HTTPS
+
+GitHub supports both SSH and HTTPS for Git operations. Here's a comparison:
+
+| Feature | SSH | HTTPS |
+|---------|-----|-------|
+| Setup Complexity | Medium (key generation required) | Easy (just username/token) |
+| Authentication | Key-based | Token-based or password |
+| Credential Storage | Keys stored locally | Requires credential helper |
+| Firewall Friendly | May be blocked (port 22) | Usually allowed (port 443) |
+| Best For | Personal machines, automation | Shared computers, quick setup |
+
+## SSH Key Types
+
+GitHub supports several SSH key algorithms:
+
+### Ed25519 (Recommended)
+- **Command**: `ssh-keygen -t ed25519 -C "your_email@example.com"`
+- **Advantages**: Small key size, fast, secure
+- **Key Size**: 256 bits
+- **Introduced**: OpenSSH 6.5 (2014)
+
+### RSA
+- **Command**: `ssh-keygen -t rsa -b 4096 -C "your_email@example.com"`
+- **Advantages**: Widely compatible
+- **Key Size**: Minimum 2048 bits, recommended 4096 bits
+- **Note**: Older algorithm, larger keys than Ed25519
+
+### ECDSA
+- **Command**: `ssh-keygen -t ecdsa -b 521 -C "your_email@example.com"`
+- **Advantages**: Good performance
+- **Note**: Concerns about NSA influence on the standard
+
+### DSA (Deprecated)
+- **Not recommended**: Considered insecure by modern standards
+- GitHub deprecated DSA key support in 2022
+
+## Common SSH Use Cases with GitHub
+
+1. **Cloning Repositories**
+   ```bash
+   git clone git@github.com:username/repository.git
+   ```
+
+2. **Adding Remote Repositories**
+   ```bash
+   git remote add origin git@github.com:username/repository.git
+   ```
+
+3. **Pushing Changes**
+   ```bash
+   git push origin main
+   ```
+
+4. **Pulling Updates**
+   ```bash
+   git pull origin main
+   ```
+
+## Security Considerations
+
+### Best Practices
+
+1. **Use Strong Passphrases**: Always protect your SSH keys with a strong passphrase
+2. **Use Ed25519**: Prefer Ed25519 over RSA for new keys
+3. **Keep Private Keys Private**: Never share your private key
+4. **Use ssh-agent**: Store decrypted keys in memory for convenience
+5. **Regular Key Rotation**: Periodically generate new keys and remove old ones
+6. **Audit Keys**: Regularly review SSH keys in your GitHub account
+
+### What to Protect
+
+- **Private Key** (`id_ed25519`, `id_rsa`): NEVER share or commit to repositories
+- **Passphrase**: Keep it secret and strong
+
+### What You Can Share
+
+- **Public Key** (`id_ed25519.pub`, `id_rsa.pub`): Safe to share, add to GitHub
+
+## SSH Agent
+
+The SSH agent is a helper program that manages your SSH keys:
+
+- **Purpose**: Stores decrypted private keys in memory
+- **Benefit**: You only need to enter your passphrase once per session
+- **Security**: Keys are kept in memory, not on disk in decrypted form
+
+## Next Steps
+
+Now that you understand SSH, you can:
+
+1. [Check for Existing SSH Keys](./checking-for-existing-ssh-keys.md)
+2. [Generate a New SSH Key](./generating-a-new-ssh-key.md)
+3. [Add Your SSH Key to GitHub](./adding-ssh-key-to-github.md)
+
+## Additional Resources
+
+- [OpenSSH Official Website](https://www.openssh.com/)
+- [SSH Protocol on Wikipedia](https://en.wikipedia.org/wiki/Secure_Shell)
+- [GitHub's SSH Documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
+- [The Secure Shell (SSH) Authentication Protocol (RFC 4252)](https://tools.ietf.org/html/rfc4252)

--- a/docs/ssh/adding-ssh-key-to-github.md
+++ b/docs/ssh/adding-ssh-key-to-github.md
@@ -1,0 +1,398 @@
+# Adding a New SSH Key to Your GitHub Account
+
+After generating an SSH key, you need to add the public key to your GitHub account to enable SSH access for Git operations.
+
+## Prerequisites
+
+- [Generated an SSH key pair](./generating-a-new-ssh-key.md)
+- A GitHub account
+- Access to your public key file (e.g., `~/.ssh/id_ed25519.pub`)
+
+## Quick Overview
+
+1. Copy your public SSH key to your clipboard
+2. Navigate to GitHub SSH settings
+3. Add the new SSH key
+4. Test your connection
+
+## Step 1: Copy Your SSH Public Key
+
+### macOS
+
+```bash
+pbcopy < ~/.ssh/id_ed25519.pub
+```
+
+This copies the contents directly to your clipboard.
+
+If `pbcopy` isn't available, display the key and copy it manually:
+```bash
+cat ~/.ssh/id_ed25519.pub
+```
+
+### Linux
+
+#### Using xclip (X11)
+```bash
+xclip -sel clip < ~/.ssh/id_ed25519.pub
+```
+
+If `xclip` isn't installed:
+```bash
+# Debian/Ubuntu
+sudo apt-get install xclip
+
+# Fedora
+sudo dnf install xclip
+
+# Arch
+sudo pacman -S xclip
+```
+
+#### Using wl-clipboard (Wayland)
+```bash
+wl-copy < ~/.ssh/id_ed25519.pub
+```
+
+#### Manual Copy
+```bash
+cat ~/.ssh/id_ed25519.pub
+```
+Then select and copy the output.
+
+### Windows
+
+#### Git Bash
+```bash
+clip < ~/.ssh/id_ed25519.pub
+```
+
+#### PowerShell
+```powershell
+Get-Content ~\.ssh\id_ed25519.pub | Set-Clipboard
+```
+
+#### Manual Copy
+```bash
+cat ~/.ssh/id_ed25519.pub
+```
+Then select and copy the output.
+
+### What Your Public Key Looks Like
+
+Your public key should look something like this:
+
+```
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl your_email@example.com
+```
+
+Or for RSA:
+
+```
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC9Qn... your_email@example.com
+```
+
+**Important**: Copy the entire line, including:
+- The key type (`ssh-ed25519` or `ssh-rsa`)
+- The key data (long string of characters)
+- The comment/email at the end
+
+## Step 2: Navigate to GitHub SSH Settings
+
+### Via Web Interface
+
+1. **Log in to GitHub** at [github.com](https://github.com)
+
+2. **Click your profile photo** in the upper-right corner
+
+3. **Click Settings**
+
+4. **In the left sidebar**, click **SSH and GPG keys**
+
+5. **Click New SSH key** or **Add SSH key**
+
+### Direct Link
+
+You can also navigate directly to: [github.com/settings/ssh/new](https://github.com/settings/ssh/new)
+
+## Step 3: Add Your SSH Key
+
+On the SSH key form:
+
+### Title Field
+
+Enter a descriptive title that helps you identify this key:
+
+**Good examples:**
+- "Personal MacBook Pro"
+- "Work Laptop - Ubuntu"
+- "Home Desktop - Windows"
+- "CI/CD Server"
+
+**Why this matters:**
+- Helps you identify which key is which
+- Makes it easier to manage and remove old keys
+- Useful when you have multiple devices
+
+### Key Type
+
+Select the appropriate key type:
+- **Authentication Key** (default) - For normal Git operations
+- **Signing Key** - For commit/tag signing (advanced)
+
+For most users, choose **Authentication Key**.
+
+### Key Field
+
+1. **Paste your public key** into the "Key" field
+2. The key should start with `ssh-ed25519` or `ssh-rsa`
+3. Make sure there are no extra spaces or line breaks
+
+### Example
+
+```
+Title: Personal MacBook Pro
+Key type: Authentication Key
+Key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl your_email@example.com
+```
+
+## Step 4: Save the Key
+
+1. **Click Add SSH key**
+
+2. **Confirm your GitHub password** if prompted
+
+3. You should see a success message: "Key is now being used by your account"
+
+## Step 5: Verify the Key Was Added
+
+Your new key should now appear in the list of SSH keys with:
+- The title you provided
+- The key fingerprint (e.g., `SHA256:abcd1234...`)
+- The date it was added
+- "Never used" status (will change after first use)
+
+## Managing Multiple SSH Keys on GitHub
+
+You can add multiple SSH keys to your GitHub account:
+
+- Different keys for different computers
+- Separate keys for work and personal projects
+- Backup keys in case you lose access to one
+
+### Adding Additional Keys
+
+Repeat the process above for each new key:
+1. Generate a new key (or use an existing one)
+2. Copy the public key
+3. Add it to GitHub with a descriptive title
+
+### Example Key Organization
+
+```
+Personal MacBook Pro (Added Nov 9, 2024)
+└─ ssh-ed25519 SHA256:abcd...
+
+Work Laptop Ubuntu (Added Nov 1, 2024)
+└─ ssh-ed25519 SHA256:efgh...
+
+Home Desktop Windows (Added Oct 15, 2024)
+└─ ssh-rsa SHA256:ijkl...
+
+CI/CD Server (Added Sep 1, 2024)
+└─ ssh-ed25519 SHA256:mnop...
+```
+
+## Security Best Practices
+
+### Regular Key Audits
+
+Periodically review your SSH keys:
+1. Go to [github.com/settings/keys](https://github.com/settings/keys)
+2. Remove keys you no longer use
+3. Remove keys for devices you no longer own
+
+### When to Remove Keys
+
+Remove SSH keys when:
+- You no longer use a device
+- You've sold or given away a computer
+- A device has been lost or stolen
+- You suspect a key has been compromised
+- You're replacing an old key with a new one
+
+### How to Remove a Key
+
+1. Go to [github.com/settings/keys](https://github.com/settings/keys)
+2. Find the key you want to remove
+3. Click **Delete**
+4. Confirm the deletion
+
+## Using Different GitHub Accounts
+
+If you have multiple GitHub accounts (personal and work), you'll need:
+
+### 1. Different SSH Keys
+
+Generate separate keys:
+```bash
+ssh-keygen -t ed25519 -C "personal@example.com" -f ~/.ssh/id_ed25519_personal
+ssh-keygen -t ed25519 -C "work@company.com" -f ~/.ssh/id_ed25519_work
+```
+
+### 2. Add Each Key to the Respective Account
+
+- Log in to personal account → Add personal key
+- Log in to work account → Add work key
+
+### 3. Configure SSH Config
+
+Edit `~/.ssh/config`:
+
+```
+# Personal GitHub
+Host github.com
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/id_ed25519_personal
+
+# Work GitHub
+Host github-work
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/id_ed25519_work
+```
+
+### 4. Clone Using Different Hosts
+
+Personal repositories:
+```bash
+git clone git@github.com:personal-username/repo.git
+```
+
+Work repositories:
+```bash
+git clone git@github-work:company/repo.git
+```
+
+## Troubleshooting
+
+### "Key is already in use"
+
+This error means:
+- The key is already added to this account, OR
+- The key is added to a different GitHub account
+
+**Solution**:
+- Generate a new SSH key
+- Use a different existing key
+- Remove the key from the other account (if you own it)
+
+### "Key is invalid"
+
+Common causes:
+- Missing the key type prefix (`ssh-ed25519` or `ssh-rsa`)
+- Extra whitespace or line breaks
+- Copied the private key instead of public key
+- Corrupted key file
+
+**Solution**:
+1. Display the public key again:
+   ```bash
+   cat ~/.ssh/id_ed25519.pub
+   ```
+2. Ensure you copy the entire line
+3. Make sure it starts with `ssh-ed25519` or `ssh-rsa`
+
+### Can't Find the Public Key File
+
+If `cat ~/.ssh/id_ed25519.pub` shows "No such file":
+1. Check for RSA keys: `cat ~/.ssh/id_rsa.pub`
+2. List all SSH keys: `ls -la ~/.ssh/`
+3. If no keys exist, [generate a new SSH key](./generating-a-new-ssh-key.md)
+
+### Copied Private Key by Mistake
+
+If you accidentally pasted your **private key** (the one WITHOUT `.pub`):
+- **Delete it immediately** from GitHub
+- **Never share your private key**
+- The private key starts with `-----BEGIN OPENSSH PRIVATE KEY-----`
+- The public key starts with `ssh-ed25519` or `ssh-rsa`
+
+If you think your private key was exposed:
+1. Remove the compromised key from GitHub
+2. Generate a new SSH key pair
+3. Add the new public key to GitHub
+
+## Common Use Cases
+
+### For Personal Projects
+
+```bash
+# 1. Generate key
+ssh-keygen -t ed25519 -C "your_email@example.com"
+
+# 2. Copy public key
+cat ~/.ssh/id_ed25519.pub
+
+# 3. Add to GitHub (via web interface)
+# 4. Test connection
+ssh -T git@github.com
+```
+
+### For Organization/Work Projects
+
+```bash
+# 1. Generate work-specific key
+ssh-keygen -t ed25519 -C "work@company.com" -f ~/.ssh/id_ed25519_work
+
+# 2. Add to ssh-agent
+ssh-add ~/.ssh/id_ed25519_work
+
+# 3. Copy and add to work GitHub account
+cat ~/.ssh/id_ed25519_work.pub
+
+# 4. Configure SSH config for work repos
+# 5. Test connection
+ssh -T git@github-work
+```
+
+### For CI/CD or Deploy Keys
+
+For automated systems, consider using [Deploy Keys](./managing-deploy-keys.md) instead of personal SSH keys for:
+- Better security (repository-specific access)
+- Easier key rotation
+- Clear audit trail
+
+## Viewing Key Usage
+
+GitHub shows when each key was last used:
+
+1. Go to [github.com/settings/keys](https://github.com/settings/keys)
+2. Each key shows:
+   - **Never used** - Key hasn't been used yet
+   - **Last used within the last week** - Recently active
+   - **Last used within the last month** - Occasionally used
+   - Specific date for older usage
+
+This helps identify:
+- Keys that are actively being used
+- Stale keys that can be removed
+- Suspicious activity if a key is used from an unknown location
+
+## Next Steps
+
+After adding your SSH key to GitHub:
+
+1. [Test your SSH connection](./testing-ssh-connection.md) to verify everything works
+2. Start using SSH URLs for Git operations:
+   ```bash
+   git clone git@github.com:username/repository.git
+   ```
+3. Learn about [SSH key passphrases](./ssh-key-passphrases.md) for enhanced security
+
+## Additional Resources
+
+- [GitHub Documentation: Adding SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+- [GitHub Settings - SSH Keys](https://github.com/settings/keys)
+- [GitHub Security Best Practices](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure)

--- a/docs/ssh/checking-for-existing-ssh-keys.md
+++ b/docs/ssh/checking-for-existing-ssh-keys.md
@@ -1,0 +1,257 @@
+# Checking for Existing SSH Keys
+
+Before you generate a new SSH key, you should check to see if you already have SSH keys on your computer. You can use existing keys instead of creating new ones.
+
+## Why Check First?
+
+- You may already have SSH keys from previous setups
+- Avoid creating duplicate keys
+- Reuse existing keys if they're secure and up-to-date
+
+## Checking for SSH Keys
+
+### Step 1: Open a Terminal
+
+- **macOS**: Open Terminal (Applications > Utilities > Terminal)
+- **Windows**: Open Git Bash or PowerShell
+- **Linux**: Open your preferred terminal application
+
+### Step 2: List SSH Keys
+
+Enter the following command to see if existing SSH keys are present:
+
+```bash
+ls -al ~/.ssh
+```
+
+This lists the files in your `.ssh` directory, if they exist.
+
+### Step 3: Check the Directory Listing
+
+Look for files with these names:
+
+**Ed25519 keys (recommended):**
+- `id_ed25519` (private key)
+- `id_ed25519.pub` (public key)
+
+**RSA keys:**
+- `id_rsa` (private key)
+- `id_rsa.pub` (public key)
+
+**ECDSA keys:**
+- `id_ecdsa` (private key)
+- `id_ecdsa.pub` (public key)
+
+**DSA keys (deprecated):**
+- `id_dsa` (private key)
+- `id_dsa.pub` (public key)
+
+### Example Output
+
+If you have existing keys, you might see output like:
+
+```
+total 24
+drwx------   5 user  staff   160 Nov  9 10:00 .
+drwxr-xr-x+ 45 user  staff  1440 Nov  9 09:00 ..
+-rw-------   1 user  staff   411 Nov  8 12:00 id_ed25519
+-rw-r--r--   1 user  staff   103 Nov  8 12:00 id_ed25519.pub
+-rw-------   1 user  staff  1876 Nov  7 15:00 known_hosts
+```
+
+If you don't see any key files, you'll see an error like:
+
+```
+ls: /Users/user/.ssh: No such file or directory
+```
+
+This means you don't have any SSH keys yet and need to [generate a new SSH key](./generating-a-new-ssh-key.md).
+
+## Understanding Your Keys
+
+### Private Keys (No .pub Extension)
+
+These are your **secret** keys and should never be shared:
+- `id_ed25519`
+- `id_rsa`
+- `id_ecdsa`
+
+**Important**:
+- Keep these files secure
+- Never commit them to a repository
+- Never send them via email or messaging apps
+- They should have restrictive permissions (600 or 400)
+
+### Public Keys (.pub Extension)
+
+These are **safe to share** and are what you add to GitHub:
+- `id_ed25519.pub`
+- `id_rsa.pub`
+- `id_ecdsa.pub`
+
+You'll copy the contents of your public key file to GitHub.
+
+## What to Do If You Find Existing Keys
+
+### Option 1: Use Your Existing Key
+
+If you found an existing key and want to use it:
+
+1. **Display the public key**:
+   ```bash
+   cat ~/.ssh/id_ed25519.pub
+   # or
+   cat ~/.ssh/id_rsa.pub
+   ```
+
+2. **Copy the output** (the entire contents starting with `ssh-ed25519` or `ssh-rsa`)
+
+3. **Add it to GitHub** following the [Adding a New SSH Key to Your GitHub Account](./adding-ssh-key-to-github.md) guide
+
+### Option 2: Generate a New Key
+
+If you want to generate a new key (perhaps the existing one is old or uses an outdated algorithm):
+
+1. **Back up your existing keys** (optional):
+   ```bash
+   mkdir ~/ssh_backup
+   cp ~/.ssh/id_* ~/ssh_backup/
+   ```
+
+2. Follow the [Generating a New SSH Key](./generating-a-new-ssh-key.md) guide
+
+### Option 3: Use Multiple Keys
+
+You can have multiple SSH keys for different purposes:
+
+- Different keys for personal and work accounts
+- Different keys for different organizations
+- Separate keys for different security levels
+
+To use multiple keys, you'll need to configure your SSH config file. See the [Using Multiple SSH Keys](#using-multiple-ssh-keys) section below.
+
+## Checking Key Permissions
+
+SSH keys require specific file permissions for security. Check your key permissions:
+
+```bash
+ls -l ~/.ssh/id_ed25519
+```
+
+The private key should have permissions `-rw-------` (600):
+- Owner can read and write
+- No permissions for group or others
+
+If permissions are incorrect, fix them:
+
+```bash
+chmod 600 ~/.ssh/id_ed25519
+chmod 644 ~/.ssh/id_ed25519.pub
+```
+
+## Verifying Key Algorithm
+
+If you have an existing key but want to check what algorithm it uses:
+
+```bash
+ssh-keygen -l -f ~/.ssh/id_ed25519.pub
+```
+
+Output will show:
+```
+256 SHA256:abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234yz your_email@example.com (ED25519)
+```
+
+The last part in parentheses shows the algorithm (ED25519, RSA, ECDSA, etc.).
+
+For RSA keys, also check the bit length (first number). RSA keys should be at least 2048 bits, preferably 4096 bits.
+
+## Using Multiple SSH Keys
+
+If you need to use multiple SSH keys (for example, one for personal projects and one for work), you can configure SSH to use the right key for each host.
+
+### Create SSH Config File
+
+Create or edit `~/.ssh/config`:
+
+```bash
+nano ~/.ssh/config
+```
+
+### Add Host Configurations
+
+```
+# Personal GitHub account
+Host github.com
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519
+
+# Work GitHub account
+Host github-work
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519_work
+
+# GitLab account
+Host gitlab.com
+    HostName gitlab.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519_gitlab
+```
+
+### Use Different Hosts in Git Commands
+
+For work repositories:
+```bash
+git clone git@github-work:company/repository.git
+```
+
+For personal repositories:
+```bash
+git clone git@github.com:username/repository.git
+```
+
+## Common Issues
+
+### No .ssh Directory
+
+If `~/.ssh` doesn't exist, it means:
+- SSH has never been set up on this computer
+- You need to [generate a new SSH key](./generating-a-new-ssh-key.md)
+
+You can create the directory manually:
+```bash
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+```
+
+### Permission Denied Errors
+
+If you see "WARNING: UNPROTECTED PRIVATE KEY FILE!" or similar:
+```bash
+chmod 700 ~/.ssh
+chmod 600 ~/.ssh/id_ed25519
+chmod 644 ~/.ssh/id_ed25519.pub
+```
+
+### Multiple Keys with Same Name
+
+If you have both `id_rsa` and `id_ed25519`, SSH will try them in order. You can specify which key to use with the `-i` flag:
+
+```bash
+ssh -i ~/.ssh/id_ed25519 -T git@github.com
+```
+
+## Next Steps
+
+Depending on what you found:
+
+1. **If you have existing keys**: [Add your SSH key to GitHub](./adding-ssh-key-to-github.md)
+2. **If you don't have keys**: [Generate a new SSH key](./generating-a-new-ssh-key.md)
+3. **If you want to test**: [Test your SSH connection](./testing-ssh-connection.md)
+
+## Additional Resources
+
+- [GitHub Documentation: Checking for Existing SSH Keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys)
+- [SSH File Permissions](https://www.ssh.com/academy/ssh/config#file-permissions)

--- a/docs/ssh/generating-a-new-ssh-key.md
+++ b/docs/ssh/generating-a-new-ssh-key.md
@@ -1,0 +1,387 @@
+# Generating a New SSH Key and Adding It to the SSH Agent
+
+This guide walks you through generating a new SSH key and adding it to your SSH agent for secure authentication with GitHub.
+
+## Prerequisites
+
+- A terminal or command line interface
+- SSH client installed (comes pre-installed on macOS, Linux, and Windows 10+)
+- [Checked for existing SSH keys](./checking-for-existing-ssh-keys.md)
+
+## Step 1: Generate Your SSH Key
+
+### Recommended: Ed25519 Algorithm
+
+Generate a new SSH key using the Ed25519 algorithm:
+
+```bash
+ssh-keygen -t ed25519 -C "your_email@example.com"
+```
+
+**Parameters explained:**
+- `-t ed25519`: Specifies the Ed25519 algorithm (recommended)
+- `-C "your_email@example.com"`: Adds a label/comment (use your GitHub email)
+
+### Alternative: RSA Algorithm
+
+If your system doesn't support Ed25519 (older systems), use RSA with 4096 bits:
+
+```bash
+ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
+```
+
+**Parameters explained:**
+- `-t rsa`: Specifies the RSA algorithm
+- `-b 4096`: Sets the key length to 4096 bits
+- `-C "your_email@example.com"`: Adds a label/comment
+
+## Step 2: Choose a File Location
+
+After running the command, you'll see:
+
+```
+Generating public/private ed25519 key pair.
+Enter file in which to save the key (/home/user/.ssh/id_ed25519):
+```
+
+**Options:**
+1. **Press Enter** to accept the default location (`~/.ssh/id_ed25519`)
+2. **Type a custom path** if you want to use a different location or manage multiple keys
+
+### Default Locations
+
+- Ed25519: `~/.ssh/id_ed25519`
+- RSA: `~/.ssh/id_rsa`
+
+### Custom Location Example
+
+If you want multiple keys (e.g., for work and personal):
+
+```
+Enter file in which to save the key (/home/user/.ssh/id_ed25519): /home/user/.ssh/id_ed25519_work
+```
+
+## Step 3: Enter a Secure Passphrase
+
+You'll be prompted to enter a passphrase:
+
+```
+Enter passphrase (empty for no passphrase):
+Enter same passphrase again:
+```
+
+### Why Use a Passphrase?
+
+- **Security Layer**: Even if someone steals your private key file, they can't use it without the passphrase
+- **Best Practice**: Always use a strong passphrase
+- **ssh-agent**: You only need to enter it once per session when using ssh-agent
+
+### Passphrase Best Practices
+
+✅ **Good passphrases:**
+- At least 12-16 characters
+- Mix of letters, numbers, and symbols
+- Memorable but not easily guessable
+- Example: "MyC@t!sN4medWh1skers2024"
+
+❌ **Avoid:**
+- Leaving it empty (not recommended)
+- Dictionary words
+- Personal information (birthdate, name, etc.)
+- Short passphrases (less than 8 characters)
+
+## Step 4: Verify Key Generation
+
+After entering your passphrase, you should see output like:
+
+```
+Your identification has been saved in /home/user/.ssh/id_ed25519
+Your public key has been saved in /home/user/.ssh/id_ed25519.pub
+The key fingerprint is:
+SHA256:abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx your_email@example.com
+The key's randomart image is:
++--[ED25519 256]--+
+|    .o.          |
+|   .  o          |
+|  . .. .         |
+| . o. o          |
+|  +.o.o S        |
+| ..=.= + .       |
+|  o.B.* o        |
+| . *oB.=         |
+|  E.=*B+.        |
++----[SHA256]-----+
+```
+
+You now have two files:
+- **Private key**: `~/.ssh/id_ed25519` (keep this secret!)
+- **Public key**: `~/.ssh/id_ed25519.pub` (this is what you share)
+
+## Step 5: Add Your SSH Key to the SSH Agent
+
+The SSH agent manages your SSH keys and remembers your passphrase so you don't have to enter it repeatedly.
+
+### macOS
+
+#### Start the SSH Agent
+
+```bash
+eval "$(ssh-agent -s)"
+```
+
+You should see output like:
+```
+Agent pid 12345
+```
+
+#### Configure SSH to Use Keychain (macOS 10.12+)
+
+First, check if `~/.ssh/config` exists:
+
+```bash
+ls ~/.ssh/config
+```
+
+If it doesn't exist, create it:
+
+```bash
+touch ~/.ssh/config
+```
+
+Add this configuration:
+
+```bash
+cat >> ~/.ssh/config << EOF
+Host github.com
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519
+EOF
+```
+
+**Note**: If you're not using macOS Sierra 10.12.2 or later, omit the `UseKeychain yes` line.
+
+#### Add Your SSH Key
+
+```bash
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+```
+
+On older macOS versions, use:
+```bash
+ssh-add -K ~/.ssh/id_ed25519
+```
+
+If you didn't use the default filename:
+```bash
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519_work
+```
+
+### Linux
+
+#### Start the SSH Agent
+
+```bash
+eval "$(ssh-agent -s)"
+```
+
+You should see:
+```
+Agent pid 12345
+```
+
+#### Add Your SSH Key
+
+```bash
+ssh-add ~/.ssh/id_ed25519
+```
+
+If you used a custom filename:
+```bash
+ssh-add ~/.ssh/id_ed25519_work
+```
+
+### Windows (Git Bash or PowerShell)
+
+#### Git Bash
+
+Start the SSH agent:
+```bash
+eval "$(ssh-agent -s)"
+```
+
+Add your key:
+```bash
+ssh-add ~/.ssh/id_ed25519
+```
+
+#### PowerShell
+
+Start the SSH agent (run as Administrator):
+```powershell
+Get-Service -Name ssh-agent | Set-Service -StartupType Automatic
+Start-Service ssh-agent
+```
+
+Add your key:
+```powershell
+ssh-add ~\.ssh\id_ed25519
+```
+
+## Step 6: Verify the Key Was Added
+
+List all keys currently managed by the SSH agent:
+
+```bash
+ssh-add -l
+```
+
+You should see output like:
+```
+256 SHA256:abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx your_email@example.com (ED25519)
+```
+
+## Complete Example Workflow
+
+Here's a complete example from start to finish:
+
+```bash
+# 1. Generate the key
+ssh-keygen -t ed25519 -C "your_email@example.com"
+
+# 2. Press Enter to accept default location
+# 3. Enter a strong passphrase (twice)
+
+# 4. Start SSH agent
+eval "$(ssh-agent -s)"
+
+# 5. Add key to agent
+ssh-add ~/.ssh/id_ed25519
+
+# 6. Display your public key to copy it
+cat ~/.ssh/id_ed25519.pub
+```
+
+## Managing Multiple SSH Keys
+
+If you need multiple keys (for different accounts or services):
+
+### Generate with Different Names
+
+```bash
+# Personal GitHub
+ssh-keygen -t ed25519 -C "personal@example.com" -f ~/.ssh/id_ed25519_personal
+
+# Work GitHub
+ssh-keygen -t ed25519 -C "work@company.com" -f ~/.ssh/id_ed25519_work
+```
+
+### Configure SSH Config
+
+Edit `~/.ssh/config`:
+
+```
+# Personal GitHub
+Host github.com
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/id_ed25519_personal
+  AddKeysToAgent yes
+
+# Work GitHub
+Host github-work
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/id_ed25519_work
+  AddKeysToAgent yes
+```
+
+### Add All Keys to Agent
+
+```bash
+ssh-add ~/.ssh/id_ed25519_personal
+ssh-add ~/.ssh/id_ed25519_work
+```
+
+## Common Issues and Solutions
+
+### Issue: "Could not open a connection to your authentication agent"
+
+**Solution**: Start the SSH agent first:
+```bash
+eval "$(ssh-agent -s)"
+```
+
+### Issue: "Permission denied (publickey)"
+
+**Causes**:
+1. Key not added to agent
+2. Wrong permissions on SSH files
+3. Key not added to GitHub account
+
+**Solutions**:
+```bash
+# Add key to agent
+ssh-add ~/.ssh/id_ed25519
+
+# Fix permissions
+chmod 700 ~/.ssh
+chmod 600 ~/.ssh/id_ed25519
+chmod 644 ~/.ssh/id_ed25519.pub
+
+# Verify key is loaded
+ssh-add -l
+```
+
+### Issue: "Bad passphrase" or can't remember passphrase
+
+If you forgot your passphrase, you cannot recover it. You'll need to:
+1. Generate a new SSH key pair
+2. Add the new public key to GitHub
+3. Remove the old key from GitHub
+
+### Issue: ssh-add: illegal option -- K
+
+On newer macOS versions, use `--apple-use-keychain` instead of `-K`:
+```bash
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+```
+
+## Security Best Practices
+
+1. **Always use a passphrase** to protect your private key
+2. **Never share your private key** (`id_ed25519` or `id_rsa`)
+3. **Keep backups** of your keys in a secure location (encrypted storage)
+4. **Use different keys** for different security contexts
+5. **Set proper file permissions**:
+   ```bash
+   chmod 700 ~/.ssh
+   chmod 600 ~/.ssh/id_ed25519
+   chmod 644 ~/.ssh/id_ed25519.pub
+   ```
+
+## What's in Your Public Key?
+
+Your public key file (`id_ed25519.pub`) contains:
+```
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGhvbWVicmV3L2FkbWluIHBhc3N3b3JkIG5vdCBleHBvc2Vk your_email@example.com
+```
+
+Parts:
+1. **Algorithm**: `ssh-ed25519`
+2. **Key data**: `AAAAC3NzaC1lZDI1NTE5...` (the actual public key)
+3. **Comment**: `your_email@example.com` (identifier/label)
+
+## Next Steps
+
+Now that you've generated your SSH key and added it to the SSH agent:
+
+1. [Add your SSH key to your GitHub account](./adding-ssh-key-to-github.md)
+2. [Test your SSH connection](./testing-ssh-connection.md)
+3. Learn about [Working with SSH key passphrases](./ssh-key-passphrases.md)
+
+## Additional Resources
+
+- [GitHub Documentation: Generating a New SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
+- [OpenSSH Manual: ssh-keygen](https://man.openbsd.org/ssh-keygen)
+- [SSH Academy: SSH Keys](https://www.ssh.com/academy/ssh-keys)

--- a/docs/ssh/managing-deploy-keys.md
+++ b/docs/ssh/managing-deploy-keys.md
@@ -1,0 +1,653 @@
+# Managing Deploy Keys
+
+Deploy keys are SSH keys that grant access to a single GitHub repository. They're ideal for automated deployments, CI/CD pipelines, and server-based operations.
+
+## What are Deploy Keys?
+
+Deploy keys are SSH keys associated with a specific repository rather than a user account. They provide repository-level access control and are commonly used for:
+
+- Automated deployments
+- CI/CD systems
+- Build servers
+- Production servers pulling code
+
+### Deploy Keys vs Personal SSH Keys
+
+| Feature | Personal SSH Keys | Deploy Keys |
+|---------|------------------|-------------|
+| **Scope** | All accessible repositories | Single repository |
+| **Account** | Tied to user account | Tied to repository |
+| **Access** | Based on user permissions | Read-only or read-write |
+| **Best For** | Personal development | Automation, servers |
+| **Rotation** | Affects all repos | Only one repository |
+| **Audit Trail** | User's actions | Repository-specific |
+
+## When to Use Deploy Keys
+
+### Good Use Cases
+
+✅ **Production/Staging Servers**
+- Server needs to pull code from a specific repository
+- Limited scope reduces security risk
+
+✅ **CI/CD Pipelines**
+- GitHub Actions, Jenkins, GitLab CI, CircleCI
+- Automated testing and deployment
+
+✅ **Automated Deployment Systems**
+- Deployment scripts
+- Configuration management (Ansible, Chef, Puppet)
+
+✅ **Multiple Servers, Same Repository**
+- Each server gets its own deploy key
+- Easy to revoke access for specific servers
+
+### When NOT to Use Deploy Keys
+
+❌ **Personal Development**
+- Use personal SSH keys instead
+- More flexible for multiple repositories
+
+❌ **Multiple Repositories**
+- One deploy key per repository
+- Use personal keys or machine users for multi-repo access
+
+❌ **User-Based Operations**
+- Commits should be associated with users
+- Use personal keys for development
+
+## Creating a Deploy Key
+
+### Step 1: Generate a New SSH Key
+
+On the server that needs access:
+
+```bash
+ssh-keygen -t ed25519 -C "deploy-key-production-server" -f ~/.ssh/deploy_key_ed25519
+```
+
+**Parameters:**
+- `-t ed25519`: Key type (recommended)
+- `-C "description"`: Label for the key
+- `-f filename`: Specific filename for the key
+
+**Important**: Don't use a passphrase for deploy keys (press Enter twice when prompted), since automated systems can't enter passphrases.
+
+### Step 2: Copy the Public Key
+
+```bash
+cat ~/.ssh/deploy_key_ed25519.pub
+```
+
+Copy the entire output (starts with `ssh-ed25519`).
+
+### Step 3: Add Deploy Key to Repository
+
+1. **Navigate to your repository** on GitHub
+2. **Click Settings** (repository settings, not your profile)
+3. **Click Deploy keys** in the left sidebar
+4. **Click Add deploy key**
+5. **Fill in the form**:
+   - **Title**: Descriptive name (e.g., "Production Server", "CI/CD Pipeline")
+   - **Key**: Paste the public key
+   - **Allow write access**: Check if the key needs to push code (optional)
+6. **Click Add key**
+
+### Step 4: Test the Deploy Key
+
+On the server:
+
+```bash
+ssh -T -i ~/.ssh/deploy_key_ed25519 git@github.com
+```
+
+You should see:
+```
+Hi username/repository! You've successfully authenticated, but GitHub does not provide shell access.
+```
+
+Note: It shows the repository name, not your username.
+
+### Step 5: Configure Git to Use Deploy Key
+
+On the server, configure Git to use this key:
+
+#### Option 1: SSH Config (Recommended)
+
+Edit `~/.ssh/config`:
+
+```
+Host github.com-myrepo
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/deploy_key_ed25519
+    IdentitiesOnly yes
+```
+
+Clone the repository:
+```bash
+git clone git@github.com-myrepo:username/repository.git
+```
+
+Or update existing repository:
+```bash
+cd /path/to/repository
+git remote set-url origin git@github.com-myrepo:username/repository.git
+```
+
+#### Option 2: GIT_SSH_COMMAND Environment Variable
+
+```bash
+export GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key_ed25519"
+git clone git@github.com:username/repository.git
+```
+
+Add to deployment scripts or `~/.bashrc`.
+
+#### Option 3: Core.sshCommand Git Config
+
+```bash
+git config core.sshCommand "ssh -i ~/.ssh/deploy_key_ed25519 -F /dev/null"
+```
+
+This only affects the current repository.
+
+## Read-Only vs Read-Write Deploy Keys
+
+### Read-Only (Default)
+
+**Permissions:**
+- Clone repository
+- Pull updates
+- Read repository contents
+
+**Use cases:**
+- Production servers pulling code
+- Build systems
+- Monitoring/backup systems
+
+**Setup:**
+- Leave "Allow write access" unchecked when adding the key
+
+### Read-Write
+
+**Permissions:**
+- Everything read-only can do
+- Push commits
+- Force push (if not protected)
+- Create/delete branches (if not protected)
+
+**Use cases:**
+- CI/CD systems that push artifacts
+- Automated version bumping
+- Automated changelog generation
+- Bot accounts
+
+**Setup:**
+- Check "Allow write access" when adding the key
+
+**Security considerations:**
+- Only enable when necessary
+- Protect important branches (main/master)
+- Use branch protection rules
+
+## Managing Multiple Deploy Keys
+
+### Scenario: Multiple Servers, One Repository
+
+Each server should have its own deploy key:
+
+**Production Server:**
+```bash
+ssh-keygen -t ed25519 -C "production-server" -f ~/.ssh/deploy_key_prod
+```
+
+**Staging Server:**
+```bash
+ssh-keygen -t ed25519 -C "staging-server" -f ~/.ssh/deploy_key_staging
+```
+
+Add both public keys to the repository with different titles:
+- "Production Server - prod01.example.com"
+- "Staging Server - staging01.example.com"
+
+**Benefits:**
+- Revoke access to one server without affecting others
+- Track which server accessed the repository
+- Different access levels (e.g., staging can be read-write, production read-only)
+
+### Scenario: Multiple Repositories, One Server
+
+Create separate deploy keys for each repository:
+
+```bash
+ssh-keygen -t ed25519 -C "server-repo1" -f ~/.ssh/deploy_key_repo1
+ssh-keygen -t ed25519 -C "server-repo2" -f ~/.ssh/deploy_key_repo2
+```
+
+Configure SSH to use the right key:
+
+`~/.ssh/config`:
+```
+Host github.com-repo1
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/deploy_key_repo1
+
+Host github.com-repo2
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/deploy_key_repo2
+```
+
+Clone repositories:
+```bash
+git clone git@github.com-repo1:username/repo1.git
+git clone git@github.com-repo2:username/repo2.git
+```
+
+## Deploy Keys in CI/CD
+
+### GitHub Actions
+
+GitHub Actions has built-in authentication, but you can use deploy keys for external repositories.
+
+#### Setup
+
+1. **Generate deploy key** (without passphrase):
+   ```bash
+   ssh-keygen -t ed25519 -C "github-actions" -f deploy_key -N ""
+   ```
+
+2. **Add public key to repository** as deploy key
+
+3. **Add private key as GitHub Secret**:
+   - Repository Settings → Secrets → Actions
+   - Name: `DEPLOY_KEY`
+   - Value: Contents of private key file
+
+#### Workflow Usage
+
+`.github/workflows/deploy.yml`:
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Clone private repo
+        run: |
+          GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key" git clone git@github.com:username/private-repo.git
+```
+
+### GitLab CI
+
+`.gitlab-ci.yml`:
+```yaml
+before_script:
+  - apt-get update -qq && apt-get install -y -qq ssh
+  - mkdir -p ~/.ssh
+  - echo "$DEPLOY_KEY" | base64 -d > ~/.ssh/deploy_key
+  - chmod 600 ~/.ssh/deploy_key
+  - ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+deploy:
+  script:
+    - GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key" git clone git@github.com:username/repo.git
+```
+
+### Jenkins
+
+1. **Install SSH Agent Plugin**
+
+2. **Add SSH Credential**:
+   - Jenkins → Credentials → System → Global credentials
+   - Kind: SSH Username with private key
+   - ID: `github-deploy-key`
+   - Username: `git`
+   - Private Key: Paste deploy key
+
+3. **Use in Pipeline**:
+   ```groovy
+   pipeline {
+       agent any
+       stages {
+           stage('Checkout') {
+               steps {
+                   sshagent(['github-deploy-key']) {
+                       sh 'git clone git@github.com:username/repo.git'
+                   }
+               }
+           }
+       }
+   }
+   ```
+
+### CircleCI
+
+`.circleci/config.yml`:
+```yaml
+version: 2.1
+
+jobs:
+  deploy:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "SO:ME:FIN:GER:PR:IN:T"
+      - checkout
+      - run:
+          name: Deploy
+          command: |
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+            git clone git@github.com:username/repo.git
+```
+
+## Deployment Workflow Example
+
+### Simple Pull-Based Deployment
+
+**Server script** (`/opt/deploy/pull_updates.sh`):
+```bash
+#!/bin/bash
+
+REPO_DIR="/var/www/myapp"
+SSH_KEY="/home/deployer/.ssh/deploy_key_ed25519"
+
+cd $REPO_DIR
+
+# Pull latest changes
+GIT_SSH_COMMAND="ssh -i $SSH_KEY" git pull origin main
+
+# Run deployment steps
+npm install
+npm run build
+sudo systemctl restart myapp
+
+echo "Deployment completed at $(date)"
+```
+
+**Cron job** (run every 15 minutes):
+```bash
+crontab -e
+```
+
+Add:
+```
+*/15 * * * * /opt/deploy/pull_updates.sh >> /var/log/deploy.log 2>&1
+```
+
+### Webhook-Based Deployment
+
+**Server script** (`/opt/deploy/webhook_handler.sh`):
+```bash
+#!/bin/bash
+
+REPO_DIR="/var/www/myapp"
+SSH_KEY="/home/deployer/.ssh/deploy_key_ed25519"
+LOCK_FILE="/tmp/deploy.lock"
+
+# Prevent concurrent deployments
+if [ -f "$LOCK_FILE" ]; then
+    echo "Deployment already in progress"
+    exit 1
+fi
+
+touch $LOCK_FILE
+
+cd $REPO_DIR
+
+# Pull and deploy
+GIT_SSH_COMMAND="ssh -i $SSH_KEY" git fetch origin
+GIT_SSH_COMMAND="ssh -i $SSH_KEY" git reset --hard origin/main
+
+npm install
+npm run build
+sudo systemctl restart myapp
+
+rm $LOCK_FILE
+echo "Deployment completed at $(date)"
+```
+
+**Webhook receiver** (using webhook):
+```bash
+# Install webhook: https://github.com/adnanh/webhook
+# Configure in /etc/webhook/hooks.json
+
+[
+  {
+    "id": "deploy-myapp",
+    "execute-command": "/opt/deploy/webhook_handler.sh",
+    "command-working-directory": "/var/www/myapp",
+    "trigger-rule": {
+      "match": {
+        "type": "payload-hash-sha256",
+        "secret": "your-webhook-secret",
+        "parameter": {
+          "source": "header",
+          "name": "X-Hub-Signature-256"
+        }
+      }
+    }
+  }
+]
+```
+
+## Security Best Practices
+
+### 1. No Passphrases for Deploy Keys
+
+Deploy keys typically don't use passphrases because:
+- Automated systems can't enter passphrases
+- Keys are usually protected by file permissions and server access control
+
+**Mitigation:**
+- Strict file permissions (600)
+- Server-level security
+- Principle of least privilege (read-only when possible)
+
+### 2. Least Privilege
+
+- **Read-only by default**: Only enable write access when necessary
+- **Repository-specific**: One key per repository
+- **Server-specific**: Different keys for different servers
+
+### 3. Regular Auditing
+
+Periodically review deploy keys:
+- Repository Settings → Deploy keys
+- Remove keys for decommissioned servers
+- Rotate keys annually
+
+### 4. Descriptive Names
+
+Use descriptive titles that include:
+- Server name/identifier
+- Purpose
+- Date added
+
+**Good examples:**
+- "Production Server - prod01.example.com (Added 2024-01)"
+- "CI/CD - GitHub Actions (2024-11)"
+- "Staging - AWS EC2 i-1234abcd (2024-10)"
+
+### 5. File Permissions
+
+Protect the private key:
+```bash
+chmod 600 ~/.ssh/deploy_key_ed25519
+chmod 644 ~/.ssh/deploy_key_ed25519.pub
+chown deployer:deployer ~/.ssh/deploy_key_*
+```
+
+### 6. Use Dedicated User Accounts
+
+Create a dedicated user for deployments:
+```bash
+sudo useradd -m -s /bin/bash deployer
+sudo su - deployer
+```
+
+Keep deploy keys in this user's `.ssh` directory.
+
+### 7. Enable Branch Protection
+
+For repositories with write-access deploy keys:
+- Protect main/master branch
+- Require pull request reviews
+- Require status checks
+- Prevent force pushes
+
+## Troubleshooting
+
+### Issue: "Key is already in use"
+
+**Cause**: Deploy keys must be unique across all repositories.
+
+**Solutions:**
+
+1. **Generate a new key** for this repository:
+   ```bash
+   ssh-keygen -t ed25519 -C "new-deploy-key" -f ~/.ssh/deploy_key_new
+   ```
+
+2. **Remove the key from other repository** if it's no longer needed
+
+3. **Use a machine user** for access to multiple repositories
+
+### Issue: "Permission denied (publickey)"
+
+**Check:**
+1. **Key added to repository?** Repository Settings → Deploy keys
+2. **Correct key being used?** Verify with `ssh -vT`
+3. **File permissions correct?** Should be 600
+4. **SSH config correct?** Check `~/.ssh/config`
+
+**Debug:**
+```bash
+ssh -vT -i ~/.ssh/deploy_key_ed25519 git@github.com
+```
+
+### Issue: Deploy Key Can't Push
+
+**Cause**: Deploy key is read-only
+
+**Solution:**
+1. Repository Settings → Deploy keys
+2. Find the key
+3. Click Edit (or delete and re-add)
+4. Check "Allow write access"
+5. Save changes
+
+### Issue: Multiple Keys Conflict
+
+**Solution**: Use SSH config with `IdentitiesOnly yes`:
+
+```
+Host github.com-myrepo
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/deploy_key_ed25519
+    IdentitiesOnly yes
+```
+
+This prevents SSH from trying other keys.
+
+## Rotating Deploy Keys
+
+Best practice: Rotate deploy keys annually or when:
+- Server is compromised
+- Employee with access leaves
+- Key may have been exposed
+- General security audit
+
+### Rotation Process
+
+1. **Generate new deploy key**:
+   ```bash
+   ssh-keygen -t ed25519 -C "deploy-key-2025" -f ~/.ssh/deploy_key_new
+   ```
+
+2. **Add new key to repository** (don't remove old one yet)
+
+3. **Update server configuration** to use new key
+
+4. **Test deployment** with new key
+
+5. **Remove old key** from repository once confirmed working
+
+6. **Delete old key files** from server:
+   ```bash
+   rm ~/.ssh/deploy_key_old ~/.ssh/deploy_key_old.pub
+   ```
+
+## Machine Users (Alternative)
+
+For access to multiple repositories, consider a **machine user**:
+
+### What is a Machine User?
+
+- Dedicated GitHub account for automation
+- Not associated with a person
+- Can access multiple repositories
+- Uses personal SSH keys, not deploy keys
+
+### When to Use
+
+- Need access to multiple repositories
+- Complex CI/CD workflows
+- Organization-wide automation
+
+### Setup
+
+1. Create new GitHub account (e.g., `acme-bot`)
+2. Generate SSH key for the machine
+3. Add SSH key to machine user account
+4. Invite machine user to repositories
+5. Grant appropriate permissions
+
+**Note**: GitHub Free doesn't support machine users in private repos. Consider GitHub Pro or deploy keys.
+
+## Viewing Deploy Key Activity
+
+### Last Used
+
+Repository Settings → Deploy keys shows:
+- When key was added
+- Last used timestamp
+- "Never used" if not yet used
+
+### Audit Log (GitHub Enterprise)
+
+Organization-level audit logs show:
+- Deploy key additions/removals
+- Repository access via deploy keys
+- Timestamp and user who added the key
+
+## Next Steps
+
+- Review [SSH Agent Forwarding](./ssh-agent-forwarding.md) for alternative access patterns
+- Learn about [Testing SSH Connections](./testing-ssh-connection.md)
+- Explore [SSH Key Passphrases](./ssh-key-passphrases.md) for personal keys
+
+## Additional Resources
+
+- [GitHub: Managing Deploy Keys](https://docs.github.com/en/developers/overview/managing-deploy-keys)
+- [GitHub: Machine Users](https://docs.github.com/en/developers/overview/managing-deploy-keys#machine-users)
+- [CI/CD Best Practices](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)

--- a/docs/ssh/ssh-agent-forwarding.md
+++ b/docs/ssh/ssh-agent-forwarding.md
@@ -1,0 +1,522 @@
+# Using SSH Agent Forwarding
+
+SSH agent forwarding allows you to use your local SSH keys on a remote server without copying your private keys to that server. This is useful when you need to access Git repositories from a remote server.
+
+## What is SSH Agent Forwarding?
+
+SSH agent forwarding securely forwards your local SSH authentication to a remote server, allowing the remote server to use your local SSH keys for authentication to other services.
+
+### How It Works
+
+1. **You connect** to a remote server via SSH
+2. **Agent forwarding is enabled** during the connection
+3. **Remote server can use** your local SSH keys (without having access to the private keys themselves)
+4. **You can interact** with Git repositories from the remote server using your local credentials
+
+### Example Scenario
+
+```
+Your Local Machine → Remote Server → GitHub
+   (has SSH key)    (agent forward)   (authenticates)
+```
+
+You can clone/push/pull from GitHub on the remote server using your local SSH key, without copying your private key to the server.
+
+## When to Use Agent Forwarding
+
+### Good Use Cases
+
+✅ **Deploying from a bastion/jump host**
+- Access GitHub from a server behind a firewall
+- Deploy code from a staging/build server
+
+✅ **Temporary access on trusted servers**
+- Your own VPS or cloud instance
+- Company-owned development servers
+
+✅ **Development environments**
+- Remote development setups
+- Cloud-based IDEs
+
+### When NOT to Use Agent Forwarding
+
+❌ **Shared or untrusted servers**
+- Anyone with root access on the remote server can use your forwarded credentials
+- Multi-tenant systems
+- Servers you don't fully control
+
+❌ **Production servers**
+- Use [deploy keys](./managing-deploy-keys.md) instead
+- More secure and auditable
+
+❌ **Long-running processes**
+- Agent forwarding only works while you're connected
+- Use deploy keys for continuous deployment
+
+## Security Considerations
+
+### Risks
+
+1. **Root access vulnerability**: Anyone with root/sudo on the remote server can hijack your agent socket
+2. **Session hijacking**: While connected, others could potentially use your forwarded credentials
+3. **No audit trail**: Actions appear to come from your account but from the remote server
+
+### Mitigation Strategies
+
+1. **Only use on trusted servers you control**
+2. **Disconnect when not actively using**
+3. **Use time-limited agent forwarding**
+4. **Prefer deploy keys for automated tasks**
+5. **Monitor your GitHub security log**
+
+### Safer Alternatives
+
+- **Deploy Keys**: Repository-specific, read-only or read-write access
+- **SSH Certificates**: Short-lived, auditable credentials
+- **HTTPS with Personal Access Tokens**: Can be scoped and revoked easily
+
+## Enabling SSH Agent Forwarding
+
+### Method 1: Command Line Flag
+
+Enable forwarding for a single connection:
+
+```bash
+ssh -A user@remote-server.com
+```
+
+**Parameters:**
+- `-A`: Enable agent forwarding for this connection
+
+### Method 2: SSH Config File
+
+Enable for specific hosts in `~/.ssh/config`:
+
+```
+Host trusted-server
+    HostName server.example.com
+    User username
+    ForwardAgent yes
+
+Host github.com
+    ForwardAgent no
+```
+
+**Best practice**: Only enable for specific, trusted hosts, not globally.
+
+### Method 3: Global (Not Recommended)
+
+Enable for all connections (insecure):
+
+```
+Host *
+    ForwardAgent yes
+```
+
+**Warning**: This forwards your agent to every SSH connection. Only use if you understand the risks.
+
+## Testing Agent Forwarding
+
+### Step 1: Verify Local ssh-agent
+
+On your local machine:
+
+```bash
+ssh-add -l
+```
+
+You should see your SSH key listed:
+```
+256 SHA256:abcd1234... your_email@example.com (ED25519)
+```
+
+### Step 2: Connect with Forwarding
+
+```bash
+ssh -A user@remote-server.com
+```
+
+### Step 3: Verify on Remote Server
+
+Once connected to the remote server:
+
+```bash
+ssh-add -l
+```
+
+You should see the same key from your local machine.
+
+### Step 4: Test GitHub Connection
+
+On the remote server:
+
+```bash
+ssh -T git@github.com
+```
+
+You should see:
+```
+Hi your-username! You've successfully authenticated, but GitHub does not provide shell access.
+```
+
+## Practical Example
+
+### Scenario: Deploying Code from a Remote Server
+
+#### Setup
+
+**Local machine** (`~/.ssh/config`):
+```
+Host deploy-server
+    HostName deploy.example.com
+    User deployer
+    ForwardAgent yes
+    IdentityFile ~/.ssh/id_ed25519
+```
+
+#### Workflow
+
+1. **Connect to remote server**:
+   ```bash
+   ssh deploy-server
+   ```
+
+2. **On remote server, clone repository**:
+   ```bash
+   git clone git@github.com:username/private-repo.git
+   ```
+
+3. **Make changes and push**:
+   ```bash
+   cd private-repo
+   # make changes
+   git add .
+   git commit -m "Update deployment"
+   git push origin main
+   ```
+
+All Git operations use your local SSH key via agent forwarding.
+
+## Using with Multiple Keys
+
+If you have multiple SSH keys for different GitHub accounts:
+
+### Local Configuration
+
+`~/.ssh/config`:
+```
+# Personal GitHub
+Host github.com
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519_personal
+
+# Work GitHub
+Host github-work
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519_work
+
+# Deploy Server
+Host deploy-server
+    HostName deploy.example.com
+    User deployer
+    ForwardAgent yes
+```
+
+### Remote Server Configuration
+
+On the remote server, create `~/.ssh/config`:
+
+```
+# Personal repos
+Host github.com
+    HostName github.com
+    User git
+
+# Work repos
+Host github-work
+    HostName github.com
+    User git
+```
+
+### Usage
+
+For personal repos:
+```bash
+git clone git@github.com:personal-user/repo.git
+```
+
+For work repos:
+```bash
+git clone git@github-work:company/repo.git
+```
+
+## Troubleshooting
+
+### Issue: "Permission denied (publickey)" on Remote Server
+
+**Diagnosis**:
+```bash
+# On remote server
+echo $SSH_AUTH_SOCK
+ssh-add -l
+```
+
+**If `SSH_AUTH_SOCK` is empty**:
+- Agent forwarding is not enabled
+- Use `ssh -A` or configure `~/.ssh/config`
+
+**If `ssh-add -l` shows "Could not open connection"**:
+- ssh-agent is not running locally
+- Start it: `eval "$(ssh-agent -s)"`
+- Add key: `ssh-add ~/.ssh/id_ed25519`
+
+### Issue: Agent Forwarding Works Initially but Stops
+
+**Cause**: SSH connection dropped or you disconnected
+
+**Solution**: Agent forwarding only works while connected. Reconnect:
+```bash
+ssh -A user@remote-server.com
+```
+
+### Issue: "WARNING: Agent forwarding is disabled"
+
+**Cause**: Server's SSH configuration doesn't allow agent forwarding
+
+**Solution**: Server admin must enable it in `/etc/ssh/sshd_config`:
+```
+AllowAgentForwarding yes
+```
+
+Then restart SSH service:
+```bash
+sudo systemctl restart sshd
+```
+
+### Issue: Multiple Keys, Wrong One Being Used
+
+**Check which keys are available**:
+```bash
+ssh-add -l
+```
+
+**Force specific key**:
+```bash
+# On local machine
+ssh-add -D  # Remove all keys
+ssh-add ~/.ssh/id_ed25519_work  # Add only the one you need
+ssh -A user@remote-server.com
+```
+
+### Issue: Agent Forwarding Security Warning
+
+Modern SSH may show warnings about agent forwarding security.
+
+**Acknowledge the risk** and only use on trusted servers, or:
+
+**Use ProxyJump instead** (more secure):
+```
+Host github-via-jumphost
+    HostName github.com
+    User git
+    ProxyJump user@jumphost.example.com
+    IdentityFile ~/.ssh/id_ed25519
+```
+
+## Advanced: Agent Forwarding with tmux/screen
+
+When using terminal multiplexers, agent forwarding can break when you detach/reattach.
+
+### Problem
+
+1. Connect with agent forwarding: `ssh -A user@server`
+2. Start tmux: `tmux`
+3. Detach: `Ctrl-b d`
+4. Reconnect: `ssh -A user@server`
+5. Reattach: `tmux attach`
+6. `$SSH_AUTH_SOCK` is now stale
+
+### Solution: Update SSH_AUTH_SOCK
+
+Add to `~/.bashrc` or `~/.zshrc`:
+
+```bash
+# Update SSH_AUTH_SOCK for tmux
+if [ -n "$TMUX" ]; then
+    function refresh_auth_sock() {
+        local old_sock=$SSH_AUTH_SOCK
+        export SSH_AUTH_SOCK=$(tmux show-environment | grep '^SSH_AUTH_SOCK' | cut -d= -f2)
+        if [ -z "$SSH_AUTH_SOCK" ]; then
+            export SSH_AUTH_SOCK=$old_sock
+        fi
+    }
+else
+    function refresh_auth_sock() {
+        :
+    }
+fi
+
+# Call before SSH/Git operations
+alias ssh='refresh_auth_sock; command ssh'
+alias git='refresh_auth_sock; command git'
+```
+
+Or use a helper script:
+
+```bash
+# ~/.tmux.conf
+set -g update-environment "SSH_AUTH_SOCK SSH_CONNECTION"
+```
+
+## Alternatives to Agent Forwarding
+
+### 1. Deploy Keys (Recommended for Servers)
+
+**Pros:**
+- Repository-specific access
+- No user credentials on server
+- Can be read-only
+- Better audit trail
+
+**Cons:**
+- Need separate key per repository
+- Manual setup required
+
+**Setup**: See [Managing Deploy Keys](./managing-deploy-keys.md)
+
+### 2. ProxyJump (Recommended for Jump Hosts)
+
+More secure than agent forwarding for bastion hosts:
+
+`~/.ssh/config`:
+```
+Host private-server
+    HostName 10.0.1.5
+    User developer
+    ProxyJump bastion.example.com
+    IdentityFile ~/.ssh/id_ed25519
+```
+
+Connect directly to private server through bastion:
+```bash
+ssh private-server
+```
+
+### 3. Personal Access Tokens (HTTPS)
+
+For temporary access:
+
+```bash
+# Clone with HTTPS
+git clone https://github.com/username/repo.git
+
+# Use token instead of password
+Username: your-username
+Password: ghp_yourPersonalAccessToken
+```
+
+**Pros:**
+- Can be scoped (read-only, specific repos)
+- Easy to revoke
+- No SSH setup needed
+
+**Cons:**
+- Token must be stored or cached
+- HTTPS instead of SSH
+
+## SSH Agent Forwarding Checklist
+
+Before using agent forwarding:
+
+- [ ] Do you trust the remote server completely?
+- [ ] Do you have root/admin access to the server?
+- [ ] Is this a temporary connection (not automated)?
+- [ ] Have you considered deploy keys or other alternatives?
+- [ ] Is agent forwarding enabled in your SSH config?
+- [ ] Have you tested the connection?
+- [ ] Will you disconnect when finished?
+
+If you answered "yes" to all questions, agent forwarding might be appropriate.
+
+## Best Practices
+
+1. **Selective Forwarding**: Only enable for specific trusted hosts
+2. **Time-Limited Sessions**: Disconnect when not actively using
+3. **Monitor Usage**: Check GitHub security logs for unexpected activity
+4. **Use Deploy Keys**: For production servers and automated deployments
+5. **Principle of Least Privilege**: Only forward when necessary
+6. **Audit Regularly**: Review which servers have access via your keys
+
+## Monitoring and Auditing
+
+### Check GitHub Security Log
+
+Visit [github.com/settings/security-log](https://github.com/settings/security-log) to see:
+- Git operations performed
+- IP addresses used
+- Timestamps
+
+Look for:
+- Unexpected IP addresses
+- Operations you didn't perform
+- Activity during times you weren't connected
+
+### Check SSH Key Usage
+
+Visit [github.com/settings/keys](https://github.com/settings/keys) to see:
+- When each key was last used
+- Which keys haven't been used recently
+
+## Example: Bastion Host Setup
+
+Common pattern for accessing private networks:
+
+### Architecture
+
+```
+Local Machine → Bastion Host → Private Server → GitHub
+```
+
+### Configuration
+
+`~/.ssh/config`:
+```
+# Bastion host
+Host bastion
+    HostName bastion.example.com
+    User admin
+    IdentityFile ~/.ssh/id_ed25519_bastion
+
+# Private server via bastion
+Host private-server
+    HostName 10.0.1.5
+    User developer
+    ProxyJump bastion
+    ForwardAgent yes
+    IdentityFile ~/.ssh/id_ed25519
+```
+
+### Usage
+
+```bash
+# Connect to private server through bastion
+ssh private-server
+
+# Now on private server, access GitHub
+git clone git@github.com:company/private-repo.git
+```
+
+## Next Steps
+
+- Learn about [Managing Deploy Keys](./managing-deploy-keys.md) for server-based Git access
+- Review [SSH Key Passphrases](./ssh-key-passphrases.md) for additional security
+- Explore [Testing Your SSH Connection](./testing-ssh-connection.md) for troubleshooting
+
+## Additional Resources
+
+- [GitHub: SSH Agent Forwarding](https://docs.github.com/en/developers/overview/using-ssh-agent-forwarding)
+- [SSH Academy: Agent Forwarding](https://www.ssh.com/academy/ssh/agent)
+- [OpenSSH Manual: SSH Config](https://man.openbsd.org/ssh_config)
+- [ProxyJump Documentation](https://man.openbsd.org/ssh_config#ProxyJump)

--- a/docs/ssh/ssh-key-passphrases.md
+++ b/docs/ssh/ssh-key-passphrases.md
@@ -1,0 +1,476 @@
+# Working with SSH Key Passphrases
+
+A passphrase adds an extra layer of security to your SSH keys by encrypting the private key file. This guide covers creating, changing, and managing SSH key passphrases.
+
+## What is an SSH Key Passphrase?
+
+An SSH key passphrase is a password that encrypts your private SSH key. Even if someone obtains your private key file, they cannot use it without the passphrase.
+
+### How It Works
+
+1. **Key Generation**: When you create an SSH key with a passphrase, the private key is encrypted
+2. **Key Usage**: Each time you use the key, you must enter the passphrase to decrypt it
+3. **ssh-agent**: Stores the decrypted key in memory so you only enter the passphrase once per session
+
+## Why Use a Passphrase?
+
+### Security Benefits
+
+- **Protection against theft**: If someone steals your laptop or copies your SSH key file, they still can't use it
+- **Defense in depth**: Adds a second factor of security beyond just possessing the file
+- **Compliance**: Many security policies require passphrase-protected keys
+- **Reduced impact of breaches**: If your private key is exposed, you have time to revoke it before it's used
+
+### The Trade-off
+
+**Without passphrase:**
+- ✅ More convenient (no password entry)
+- ❌ Less secure (anyone with the file can use it)
+- ❌ Dangerous if key is stolen or exposed
+
+**With passphrase:**
+- ✅ Much more secure
+- ✅ Meets security best practices
+- ⚠️ Slightly less convenient (but ssh-agent helps)
+
+## Creating a Key with a Passphrase
+
+When generating a new SSH key, you'll be prompted for a passphrase:
+
+```bash
+ssh-keygen -t ed25519 -C "your_email@example.com"
+```
+
+You'll see:
+```
+Enter passphrase (empty for no passphrase):
+Enter same passphrase again:
+```
+
+### Strong Passphrase Guidelines
+
+**Good passphrases:**
+- At least 12-16 characters
+- Mix of uppercase, lowercase, numbers, and symbols
+- Not a dictionary word or common phrase
+- Unique to this key (don't reuse passwords)
+
+**Examples of strong passphrases:**
+- `Tr0pic@l-P1n3apple!2024`
+- `MyC@t7sN@me!sWh1skers`
+- `C0ff33&D0nuts#Everyday`
+
+**Avoid:**
+- Common words: `password`, `github`, `ssh`
+- Personal info: birthday, name, username
+- Short phrases: less than 12 characters
+- Leaving it blank (empty passphrase)
+
+### Passphrase vs Password
+
+- **Password**: Usually shorter, used for login
+- **Passphrase**: Usually longer, can be a sentence or phrase
+- **Best**: Use a long, memorable phrase with modifications
+
+Example: "I drink 3 cups of coffee every morning!" → `!Dr1nk3Cup$0fC0ff33`
+
+## Adding a Passphrase to an Existing Key
+
+If you created a key without a passphrase, you can add one:
+
+```bash
+ssh-keygen -p -f ~/.ssh/id_ed25519
+```
+
+**Parameters explained:**
+- `-p`: Change the passphrase
+- `-f`: Specify the key file
+
+You'll see:
+```
+Enter old passphrase: (press Enter if there was none)
+Enter new passphrase:
+Enter same passphrase again:
+Your identification has been saved with the new passphrase.
+```
+
+## Changing an Existing Passphrase
+
+To change your passphrase:
+
+```bash
+ssh-keygen -p -f ~/.ssh/id_ed25519
+```
+
+Follow the prompts:
+```
+Enter old passphrase: [enter current passphrase]
+Enter new passphrase: [enter new passphrase]
+Enter same passphrase again: [re-enter new passphrase]
+```
+
+### When to Change Your Passphrase
+
+- Regularly as part of security hygiene (every 6-12 months)
+- If you suspect it might be compromised
+- When rotating keys
+- If you used a weak passphrase initially
+
+## Removing a Passphrase
+
+**⚠️ Warning**: Removing a passphrase reduces security significantly. Only do this if absolutely necessary.
+
+```bash
+ssh-keygen -p -f ~/.ssh/id_ed25519
+```
+
+When prompted:
+```
+Enter old passphrase: [enter current passphrase]
+Enter new passphrase: [press Enter for no passphrase]
+Enter same passphrase again: [press Enter again]
+```
+
+### When Removing Might Be Acceptable
+
+- Automated systems (CI/CD servers) - but consider using deploy keys instead
+- Highly secure, physically isolated systems
+- When protected by other security layers (disk encryption, HSM, etc.)
+
+### Better Alternatives to Removing
+
+Instead of removing the passphrase:
+1. Use ssh-agent to cache the decrypted key
+2. Use deploy keys for automation
+3. Use SSH certificates for advanced setups
+4. Use hardware security keys (YubiKey, etc.)
+
+## Using ssh-agent
+
+The SSH agent stores your decrypted keys in memory, so you only enter your passphrase once per session.
+
+### Starting ssh-agent
+
+#### macOS
+```bash
+eval "$(ssh-agent -s)"
+```
+
+#### Linux
+```bash
+eval "$(ssh-agent -s)"
+```
+
+#### Windows (Git Bash)
+```bash
+eval "$(ssh-agent -s)"
+```
+
+### Adding Your Key to ssh-agent
+
+```bash
+ssh-add ~/.ssh/id_ed25519
+```
+
+You'll be prompted:
+```
+Enter passphrase for /home/user/.ssh/id_ed25519:
+Identity added: /home/user/.ssh/id_ed25519 (your_email@example.com)
+```
+
+Now you can use the key without entering the passphrase again in this session.
+
+### Listing Keys in ssh-agent
+
+```bash
+ssh-add -l
+```
+
+Output shows loaded keys:
+```
+256 SHA256:abcd1234efgh5678... your_email@example.com (ED25519)
+```
+
+### Removing Keys from ssh-agent
+
+Remove a specific key:
+```bash
+ssh-add -d ~/.ssh/id_ed25519
+```
+
+Remove all keys:
+```bash
+ssh-add -D
+```
+
+## Platform-Specific Passphrase Management
+
+### macOS Keychain Integration
+
+macOS can store your passphrase in the system Keychain.
+
+#### Configure SSH to Use Keychain
+
+Edit `~/.ssh/config`:
+```
+Host *
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519
+```
+
+#### Add Key with Keychain
+```bash
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+```
+
+On older macOS versions:
+```bash
+ssh-add -K ~/.ssh/id_ed25519
+```
+
+**Benefits:**
+- Passphrase stored securely in Keychain
+- Automatically loaded on restart
+- Protected by macOS security
+
+### Linux with GNOME Keyring
+
+If using GNOME desktop environment:
+
+#### Install seahorse (GUI keyring manager)
+```bash
+# Ubuntu/Debian
+sudo apt-get install seahorse
+
+# Fedora
+sudo dnf install seahorse
+```
+
+#### Enable ssh-agent integration
+Add to `~/.bashrc` or `~/.zshrc`:
+```bash
+if [ -n "$DESKTOP_SESSION" ]; then
+    eval $(gnome-keyring-daemon --start)
+    export SSH_AUTH_SOCK
+fi
+```
+
+### Windows
+
+#### Git Bash
+ssh-agent runs in Git Bash session:
+```bash
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+```
+
+#### PowerShell
+Start ssh-agent service:
+```powershell
+Get-Service ssh-agent | Set-Service -StartupType Automatic
+Start-Service ssh-agent
+ssh-add ~\.ssh\id_ed25519
+```
+
+## Automatic ssh-agent Startup
+
+### macOS/Linux
+
+Add to `~/.bashrc`, `~/.zshrc`, or `~/.bash_profile`:
+
+```bash
+# Start ssh-agent if not running
+if [ -z "$SSH_AUTH_SOCK" ] ; then
+    eval "$(ssh-agent -s)" > /dev/null
+fi
+
+# Auto-add key if not already added
+if ! ssh-add -l | grep -q "your_email@example.com"; then
+    ssh-add ~/.ssh/id_ed25519 2>/dev/null
+fi
+```
+
+For macOS with Keychain:
+```bash
+# macOS: Use Keychain
+ssh-add --apple-load-keychain 2>/dev/null
+```
+
+## Security Best Practices
+
+### 1. Always Use a Passphrase
+
+**Do:**
+- Use strong passphrases on personal machines
+- Use passphrases for any key that could be stolen
+- Use passphrases for keys with broad access
+
+**Don't:**
+- Leave keys without passphrases on laptops
+- Use weak or common passphrases
+- Share your passphrase with anyone
+
+### 2. Use ssh-agent
+
+**Benefits:**
+- Convenience without sacrificing security
+- Passphrase entered once per session
+- Keys stored in memory, not on disk
+
+### 3. Lock Your Screen
+
+Since ssh-agent holds decrypted keys in memory:
+- Lock your screen when away
+- Use automatic screen locking
+- Log out of ssh sessions when finished
+
+### 4. Use Different Passphrases
+
+- Don't reuse passphrases across different SSH keys
+- Don't use the same passphrase as your login password
+- Each key should have a unique passphrase
+
+### 5. Secure Passphrase Storage
+
+If you must write down passphrases:
+- Use a password manager (1Password, Bitwarden, LastPass)
+- Never store in plain text files
+- Never commit passphrases to repositories
+- Never send via email or messaging
+
+## Recovering from Lost Passphrase
+
+**Important**: If you lose your passphrase, **you cannot recover it**. The private key is encrypted with your passphrase.
+
+### If You Forget Your Passphrase
+
+1. **Generate a new SSH key pair**:
+   ```bash
+   ssh-keygen -t ed25519 -C "your_email@example.com" -f ~/.ssh/id_ed25519_new
+   ```
+
+2. **Add the new public key to GitHub**:
+   ```bash
+   cat ~/.ssh/id_ed25519_new.pub
+   ```
+   Copy and add to [github.com/settings/keys](https://github.com/settings/keys)
+
+3. **Remove the old key from GitHub**
+   - Go to Settings → SSH and GPG keys
+   - Delete the old key
+
+4. **Update ssh-agent**:
+   ```bash
+   ssh-add ~/.ssh/id_ed25519_new
+   ```
+
+5. **Optional: Remove old key files**:
+   ```bash
+   rm ~/.ssh/id_ed25519 ~/.ssh/id_ed25519.pub
+   mv ~/.ssh/id_ed25519_new ~/.ssh/id_ed25519
+   mv ~/.ssh/id_ed25519_new.pub ~/.ssh/id_ed25519.pub
+   ```
+
+## Troubleshooting Passphrase Issues
+
+### Issue: Passphrase Prompt Every Time
+
+**Cause**: Key not added to ssh-agent
+
+**Solution**:
+```bash
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+```
+
+### Issue: "Bad passphrase"
+
+**Cause**: Incorrect passphrase entered
+
+**Solutions**:
+1. Try entering carefully (check Caps Lock)
+2. Try copying and pasting if you have it stored
+3. If forgotten, generate a new key
+
+### Issue: ssh-agent Doesn't Persist
+
+**macOS**: Use Keychain integration (see above)
+
+**Linux**: Add to startup scripts (see above)
+
+**Windows**: Set ssh-agent to start automatically
+
+### Issue: Multiple Passphrase Prompts
+
+**Cause**: Multiple keys, each with different passphrases
+
+**Solution**:
+```bash
+# Add all keys to agent
+ssh-add ~/.ssh/id_ed25519
+ssh-add ~/.ssh/id_ed25519_work
+ssh-add ~/.ssh/id_rsa
+
+# Or use config to specify which key for which host
+```
+
+### Issue: Can't Remember Which Key Has Passphrase
+
+**Check which keys have passphrases**:
+```bash
+ssh-keygen -y -f ~/.ssh/id_ed25519
+```
+
+If it prompts for passphrase, the key is encrypted.
+If it displays the public key immediately, there's no passphrase.
+
+## Advanced: Passphrase-less Keys for Automation
+
+For automated systems (CI/CD, servers), you have options:
+
+### Option 1: Deploy Keys (Recommended)
+- Repository-specific access
+- No user account required
+- Easy to rotate
+- See [Managing Deploy Keys](./managing-deploy-keys.md)
+
+### Option 2: Passphrase-less Key with Restricted Access
+```bash
+# Generate key without passphrase
+ssh-keygen -t ed25519 -C "ci-bot@example.com" -N "" -f ~/.ssh/id_ed25519_ci
+
+# Add to GitHub with minimal permissions
+# Use only for CI/CD purposes
+# Store securely (secrets management)
+```
+
+### Option 3: SSH Certificates
+- Short-lived credentials
+- Centralized management
+- Advanced setup
+- Requires certificate authority
+
+## Testing Passphrase Protection
+
+Verify your key has a passphrase:
+
+```bash
+ssh-keygen -y -f ~/.ssh/id_ed25519
+```
+
+**If protected**: Prompts for passphrase
+**If not protected**: Immediately displays public key
+
+## Next Steps
+
+- [Test your SSH connection](./testing-ssh-connection.md)
+- [Learn about SSH agent forwarding](./ssh-agent-forwarding.md)
+- [Set up deploy keys for servers](./managing-deploy-keys.md)
+
+## Additional Resources
+
+- [GitHub: Working with SSH Key Passphrases](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/working-with-ssh-key-passphrases)
+- [SSH Academy: SSH Key Passphrases](https://www.ssh.com/academy/ssh/passphrase)
+- [OpenSSH Manual: ssh-keygen](https://man.openbsd.org/ssh-keygen)
+- [OpenSSH Manual: ssh-add](https://man.openbsd.org/ssh-add)

--- a/docs/ssh/testing-ssh-connection.md
+++ b/docs/ssh/testing-ssh-connection.md
@@ -1,0 +1,455 @@
+# Testing Your SSH Connection
+
+After setting up your SSH keys, it's important to test the connection to ensure everything is working correctly before attempting to clone, push, or pull from repositories.
+
+## Prerequisites
+
+- [Generated an SSH key](./generating-a-new-ssh-key.md)
+- [Added the SSH key to your GitHub account](./adding-ssh-key-to-github.md)
+- SSH key added to your ssh-agent
+
+## Quick Test
+
+The simplest way to test your SSH connection to GitHub:
+
+```bash
+ssh -T git@github.com
+```
+
+## Expected Results
+
+### Successful Connection
+
+If everything is set up correctly, you'll see:
+
+```
+Hi username! You've successfully authenticated, but GitHub does not provide shell access.
+```
+
+**What this means:**
+- ✅ SSH connection is working
+- ✅ Your key is properly configured
+- ✅ GitHub recognizes your account
+- ✅ You can now use Git with SSH
+
+The message "does not provide shell access" is normal - GitHub doesn't allow interactive SSH sessions, only Git operations.
+
+### First-Time Connection
+
+On your first connection, you'll see a warning about host authenticity:
+
+```
+The authenticity of host 'github.com (140.82.121.4)' can't be established.
+ED25519 key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.
+This key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.
+Are you sure you want to continue connecting (yes/no/[fingerprint])?
+```
+
+**What to do:**
+1. **Verify the fingerprint** matches [GitHub's SSH key fingerprints](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)
+2. **Type `yes`** and press Enter
+3. The host will be added to your `~/.ssh/known_hosts` file
+
+GitHub's official Ed25519 fingerprint:
+```
+SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU
+```
+
+## Common Issues and Solutions
+
+### Issue 1: Permission Denied (publickey)
+
+```
+git@github.com: Permission denied (publickey).
+```
+
+**Possible causes and solutions:**
+
+#### 1. SSH key not added to GitHub
+
+**Check**: Go to [github.com/settings/keys](https://github.com/settings/keys)
+
+**Solution**: [Add your SSH key to GitHub](./adding-ssh-key-to-github.md)
+
+#### 2. SSH key not added to ssh-agent
+
+**Check**:
+```bash
+ssh-add -l
+```
+
+If you see "The agent has no identities", your key isn't loaded.
+
+**Solution**:
+```bash
+ssh-add ~/.ssh/id_ed25519
+```
+
+#### 3. Wrong key being used
+
+**Check which key SSH is trying to use**:
+```bash
+ssh -vT git@github.com
+```
+
+Look for lines like:
+```
+Offering public key: /home/user/.ssh/id_rsa
+```
+
+**Solution**: Specify the correct key:
+```bash
+ssh -i ~/.ssh/id_ed25519 -T git@github.com
+```
+
+Or configure `~/.ssh/config`:
+```
+Host github.com
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/id_ed25519
+```
+
+#### 4. Incorrect file permissions
+
+**Check permissions**:
+```bash
+ls -la ~/.ssh/
+```
+
+Private key should be `-rw-------` (600)
+Public key should be `-rw-r--r--` (644)
+
+**Solution**:
+```bash
+chmod 700 ~/.ssh
+chmod 600 ~/.ssh/id_ed25519
+chmod 644 ~/.ssh/id_ed25519.pub
+```
+
+#### 5. SSH key added to wrong GitHub account
+
+If you have multiple GitHub accounts, you might have added the key to the wrong one.
+
+**Solution**:
+- Remove the key from the incorrect account
+- Add it to the correct account
+- Or generate a new key for the second account
+
+### Issue 2: Connection Timeout
+
+```
+ssh: connect to host github.com port 22: Connection timed out
+```
+
+**Possible causes:**
+- Firewall blocking port 22
+- Network restrictions
+- ISP blocking SSH
+
+**Solution**: Use GitHub's SSH over HTTPS port:
+
+Edit `~/.ssh/config`:
+```
+Host github.com
+  Hostname ssh.github.com
+  Port 443
+  User git
+```
+
+Test again:
+```bash
+ssh -T git@github.com
+```
+
+Or test the alternate port directly:
+```bash
+ssh -T -p 443 git@ssh.github.com
+```
+
+### Issue 3: Host Key Verification Failed
+
+```
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+```
+
+**Cause**: GitHub's host key has changed in your `known_hosts` file
+
+**Solution**:
+1. **Remove the old entry**:
+   ```bash
+   ssh-keygen -R github.com
+   ```
+
+2. **Connect again** and verify the fingerprint:
+   ```bash
+   ssh -T git@github.com
+   ```
+
+### Issue 4: No Route to Host
+
+```
+ssh: connect to host github.com port 22: No route to host
+```
+
+**Possible causes:**
+- No internet connection
+- DNS resolution issues
+- Network firewall
+
+**Solutions**:
+1. **Check internet connection**:
+   ```bash
+   ping github.com
+   ```
+
+2. **Check DNS**:
+   ```bash
+   nslookup github.com
+   ```
+
+3. **Try using IP directly**:
+   ```bash
+   ssh -T git@140.82.121.3
+   ```
+
+### Issue 5: "Are you sure you want to continue connecting?"
+
+This appears on first connection and is **normal**.
+
+**Solution**: Type `yes` (not just `y`) and press Enter
+
+## Verbose Testing
+
+For detailed debugging information, use verbose mode:
+
+```bash
+ssh -vT git@github.com
+```
+
+### Understanding Verbose Output
+
+**Key sections to look for:**
+
+#### 1. SSH Keys Being Tried
+```
+debug1: Offering public key: /home/user/.ssh/id_ed25519 ED25519
+debug1: Server accepts key: /home/user/.ssh/id_ed25519 ED25519
+debug1: Authentication succeeded (publickey).
+```
+
+#### 2. Connection Details
+```
+debug1: Connecting to github.com [140.82.121.3] port 22.
+debug1: Connection established.
+```
+
+#### 3. Authentication Success
+```
+debug1: Authentication succeeded (publickey).
+Authenticated to github.com ([140.82.121.3]:22).
+```
+
+### Even More Verbose
+
+For extreme debugging:
+```bash
+ssh -vvv -T git@github.com
+```
+
+This provides extensive details about:
+- Key exchange
+- Cipher negotiation
+- Authentication attempts
+- Configuration file parsing
+
+## Testing with Specific Keys
+
+If you have multiple SSH keys, test with a specific one:
+
+```bash
+ssh -i ~/.ssh/id_ed25519 -T git@github.com
+```
+
+Or for work keys:
+```bash
+ssh -i ~/.ssh/id_ed25519_work -T git@github-work
+```
+
+## Testing Multiple GitHub Accounts
+
+If you use SSH config for multiple accounts:
+
+### Personal Account
+```bash
+ssh -T git@github.com
+```
+
+Expected:
+```
+Hi personal-username! You've successfully authenticated...
+```
+
+### Work Account
+```bash
+ssh -T git@github-work
+```
+
+Expected:
+```
+Hi work-username! You've successfully authenticated...
+```
+
+## Verifying SSH Config
+
+Display your SSH configuration:
+
+```bash
+ssh -G git@github.com
+```
+
+This shows the exact configuration SSH will use, including:
+- Hostname
+- Port
+- User
+- IdentityFile
+- Other settings
+
+## Testing Cloning
+
+After successful SSH test, try cloning a repository:
+
+```bash
+git clone git@github.com:username/repository.git
+```
+
+### Switching from HTTPS to SSH
+
+If you have an existing repository using HTTPS, switch to SSH:
+
+#### Check Current Remote
+```bash
+git remote -v
+```
+
+You'll see:
+```
+origin  https://github.com/username/repository.git (fetch)
+origin  https://github.com/username/repository.git (push)
+```
+
+#### Switch to SSH
+```bash
+git remote set-url origin git@github.com:username/repository.git
+```
+
+#### Verify
+```bash
+git remote -v
+```
+
+Now you'll see:
+```
+origin  git@github.com:username/repository.git (fetch)
+origin  git@github.com:username/repository.git (push)
+```
+
+#### Test
+```bash
+git fetch
+```
+
+## Platform-Specific Issues
+
+### macOS
+
+**Issue**: ssh-agent not persisting keys after restart
+
+**Solution**: Configure SSH to use macOS Keychain:
+
+Edit `~/.ssh/config`:
+```
+Host *
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519
+```
+
+### Windows (Git Bash)
+
+**Issue**: ssh-agent not running
+
+**Solution**:
+```bash
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+```
+
+### Linux
+
+**Issue**: ssh-agent not starting automatically
+
+**Solution**: Add to `~/.bashrc` or `~/.zshrc`:
+```bash
+if [ -z "$SSH_AUTH_SOCK" ] ; then
+  eval "$(ssh-agent -s)"
+  ssh-add ~/.ssh/id_ed25519
+fi
+```
+
+## Security Verification
+
+### Verify GitHub's SSH Key Fingerprints
+
+Always verify you're connecting to the real GitHub:
+
+**Official GitHub SSH key fingerprints:**
+
+- **RSA**: `SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8`
+- **Ed25519**: `SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU`
+- **ECDSA**: `SHA256:p2QAMXNIC1TJYWeIOttrVc98/R1BUFWu3/LiyKgUfQM`
+
+Check the fingerprint:
+```bash
+ssh-keyscan github.com | ssh-keygen -lf -
+```
+
+### Monitor for Suspicious Activity
+
+Regularly check:
+1. [GitHub SSH keys](https://github.com/settings/keys) - Remove unknown keys
+2. [Security log](https://github.com/settings/security-log) - Review recent activity
+3. Key usage dates - Identify stale or compromised keys
+
+## Complete Testing Checklist
+
+Use this checklist to verify your SSH setup:
+
+- [ ] SSH key generated
+- [ ] Public key added to GitHub account
+- [ ] Private key added to ssh-agent
+- [ ] `ssh -T git@github.com` succeeds
+- [ ] Correct GitHub username appears in message
+- [ ] Can clone a test repository
+- [ ] Can push to a repository
+- [ ] Can pull from a repository
+- [ ] SSH config file configured (if using multiple keys)
+- [ ] File permissions are correct (600 for private key)
+
+## Next Steps
+
+Once your SSH connection is working:
+
+1. Start using SSH URLs for Git operations
+2. Learn about [SSH key passphrases](./ssh-key-passphrases.md)
+3. Explore [SSH agent forwarding](./ssh-agent-forwarding.md) for advanced use cases
+4. Set up [deploy keys](./managing-deploy-keys.md) for servers
+
+## Additional Resources
+
+- [GitHub SSH Key Fingerprints](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)
+- [GitHub Documentation: Testing SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection)
+- [Troubleshooting SSH](https://docs.github.com/en/authentication/troubleshooting-ssh)
+- [Using SSH over HTTPS port](https://docs.github.com/en/authentication/troubleshooting-ssh/using-ssh-over-the-https-port)


### PR DESCRIPTION
Created a complete documentation suite for connecting to GitHub via SSH, including:
- Main overview and quick start guide
- About SSH and its benefits
- Checking for existing SSH keys
- Generating new SSH keys and adding to ssh-agent
- Adding SSH keys to GitHub account
- Testing SSH connections and troubleshooting
- Working with SSH key passphrases
- Using SSH agent forwarding
- Managing deploy keys for servers and CI/CD

Each guide includes detailed step-by-step instructions, platform-specific guidance (macOS, Linux, Windows), security best practices, troubleshooting sections, and real-world examples.