### PR TITLE
Add HTTP probe script with retry logic and detailed metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "1.0.0",
   "description": "GitHub profile repository with Claude Code integration",
   "private": true,
+  "type": "module",
   "scripts": {
-    "test": "echo \"No tests configured\" && exit 0"
+    "test": "echo \"No tests configured\" && exit 0",
+    "probe": "node probe.js"
   },
   "repository": {
     "type": "git",

--- a/probe.js
+++ b/probe.js
@@ -1,0 +1,96 @@
+// probe.js
+import http from "node:http";
+import { performance } from "node:perf_hooks";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const url = new URL("http://21.0.0.60:3080/");
+const maxRetries = 3;
+const baseDelay = 300;
+const timeoutMs = 3000;
+const maxBytes = 2048;
+
+function attempt() {
+  const t0 = performance.now();
+
+  return new Promise((resolve, reject) => {
+    const timings = { start: t0, socket: null, connect: null, response: null, end: null };
+    const req = http.get(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        method: "GET",
+        timeout: timeoutMs,
+        headers: {
+          "Accept": "text/html,*/*;q=0.8",
+          "User-Agent": "duck-probe/1.1"
+        }
+      },
+      (res) => {
+        timings.response = performance.now();
+        let received = 0;
+        const bufs = [];
+
+        res.on("data", (chunk) => {
+          if (received >= maxBytes) return;
+          const take = Math.min(chunk.length, maxBytes - received);
+          bufs.push(chunk.subarray(0, take));
+          received += take;
+        });
+
+        res.on("end", () => {
+          timings.end = performance.now();
+          const body = Buffer.concat(bufs).toString("utf8");
+          resolve({
+            ok: res.statusCode >= 200 && res.statusCode < 400,
+            status: res.statusCode,
+            headers: {
+              server: res.headers["server"] ?? null,
+              location: res.headers["location"] ?? null,
+              contentType: res.headers["content-type"] ?? null,
+            },
+            timing_ms: {
+              dns_tcp: timings.socket && timings.connect ? +(timings.connect - timings.socket).toFixed(1) : null,
+              ttfb: timings.response ? +(timings.response - (timings.connect ?? timings.start)).toFixed(1) : null,
+              total: timings.end ? +(timings.end - timings.start).toFixed(1) : null,
+            },
+            snippet: body.slice(0, 200)
+          });
+        });
+      }
+    );
+
+    req.on("socket", (sock) => {
+      timings.socket = performance.now();
+      sock.on("connect", () => {
+        timings.connect = performance.now();
+      });
+    });
+
+    req.on("timeout", () => req.destroy(new Error("timeout")));
+    req.on("error", (err) => {
+      const now = performance.now();
+      reject(Object.assign(err, {
+        timing_ms: {
+          total: +(now - t0).toFixed(1),
+        }
+      }));
+    });
+  });
+}
+
+async function probe() {
+  for (let attemptNum = 0; attemptNum <= maxRetries; attemptNum++) {
+    try {
+      const result = await attempt();
+      console.log(JSON.stringify({ attempt: attemptNum, ...result }, null, 2));
+      process.exit(result.ok ? 0 : 2);
+    } catch (err) {
+      console.error(`Attempt ${attemptNum} failed after ${err.timing_ms?.total ?? "?"}ms: ${err.message}`);
+      if (attemptNum === maxRetries) process.exit(1);
+      await sleep(2 ** attemptNum * baseDelay);
+    }
+  }
+}
+
+probe();


### PR DESCRIPTION
Implements a Node.js HTTP probe utility that:
- Tests HTTP endpoint availability with automatic retries
- Measures detailed connection timings (DNS, TCP, TTFB, total)
- Captures response headers and body snippet
- Uses exponential backoff for failed attempts
- Exits with appropriate status codes for monitoring

Updated package.json to support ES modules and added convenience script.

# Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test additions or updates

## Changes Made

<!-- List the main changes in this PR -->

-
-
-

## Testing

<!-- Describe the tests you ran and their results -->

- [ ] Tested locally
- [ ] All tests pass
- [ ] Documentation updated (if applicable)
- [ ] Code follows project style guidelines

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

<!-- Link any related issues here -->

Closes #
Related to #

## Additional Notes

<!-- Add any additional context about the PR here -->
